### PR TITLE
Fix hydra target ac_red_motion

### DIFF
--- a/future_motion/configs/model/ac_red_motion.yaml
+++ b/future_motion/configs/model/ac_red_motion.yaml
@@ -1,4 +1,4 @@
-_target_: future_motion.future_motion.FutureMotion
+_target_: future_motion.main.FutureMotion
 
 time_step_current: 10
 time_step_end: 90


### PR DESCRIPTION
Corrected hydra `_target_` for RedMotion model. 